### PR TITLE
fix: use custom button styling on linked accounts page

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -14,7 +14,8 @@
   line-height: 27px;
 }
 
-.LogInButtons:not(.FoFLogInButtons--icons) {
+.LogInButtons:not(.FoFLogInButtons--icons),
+.LinkedAccounts {
   .LogInButton--apple {
     // Size proportions from Apple
     // "minumum height: 30px"


### PR DESCRIPTION
Simple fix to apply the custom button styling to the "linked accounts" tab of a user page.

![image](https://user-images.githubusercontent.com/7406822/215903434-f33358f4-a4d6-464b-9d50-9a98b193f9dc.png)
